### PR TITLE
Updated library to match current Tesla API and add new capabilities.

### DIFF
--- a/api/authn.go
+++ b/api/authn.go
@@ -78,6 +78,8 @@ func (c *Client) GetAccessToken(in *AccessTokenInput) (*AccessTokenOutput, error
 		c.logger.Debugf("electricgopher.api.Client.GetAccessToken(): error posting request - %v", err)
 		return nil, err
 	}
+	defer res.Body.Close()
+
 	c.logger.Debugf("electricgopher.api.Client.GetAccessToken(): http response status - %s", res.Status)
 	// check for 200
 	if res.StatusCode != 200 {

--- a/api/command.go
+++ b/api/command.go
@@ -18,19 +18,39 @@ type WakeUpOutput struct {
 	Response Vehicle `json:"response"`
 }
 
-func (c *Client) Unlock(id string) (*UnlockOutput, error) {
+func (c *Client) Unlock(id string) (*CommandResponse, error) {
 	c.logger.Debugf("electricgopher.api.Client.Unlock(%v): begin", id)
 	defer c.logger.Debugf("electricgopher.api.Client.Unlock(%v): end", id)
-	out := &UnlockOutput{}
+	out := &ResponseEnvelope{}
 	err := c.doPost(fmt.Sprintf("/api/1/vehicles/%s/command/door_unlock", id), out, bytes.NewBufferString(""))
-	return out, err
+	return &out.Response, err
 }
 
-type UnlockOutput struct {
-	Response UnlockPayload `json:"response"`
+func (c *Client) OpenFrunk(id string) (*CommandResponse, error) {
+	c.logger.Debugf("electricgopher.api.Client.OpenFrunk(%v): begin", id)
+	defer c.logger.Debugf("electricgopher.api.Client.OpenFrunk(%v): end", id)
+	return c.actuateTrunk(id, "front")
 }
 
-type UnlockPayload struct {
+func (c *Client) OpenTrunk(id string) (*CommandResponse, error) {
+	c.logger.Debugf("electricgopher.api.Client.OpenTrunk(%v): begin", id)
+	defer c.logger.Debugf("electricgopher.api.Client.OpenTrunk(%v): end", id)
+	return c.actuateTrunk(id, "rear")
+}
+
+func (c *Client) actuateTrunk(id string, which string) (*CommandResponse, error) {
+	c.logger.Debugf("electricgopher.api.Client.OpenFrunk(%v): begin", id)
+	defer c.logger.Debugf("electricgopher.api.Client.OpenFrunk(%v): end", id)
+	out := &ResponseEnvelope{}
+	err := c.doPost(fmt.Sprintf("/api/1/vehicles/%s/command/actuate_trunk", id), out, bytes.NewBufferString(fmt.Sprintf("which_trunk=%s", which)))
+	return &out.Response, err
+}
+
+type ResponseEnvelope struct {
+	Response CommandResponse `json:"response"`
+}
+
+type CommandResponse struct {
 	Reason string `json:"reason"`
 	Result bool   `json:"result"`
 }

--- a/api/command.go
+++ b/api/command.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func (c *Client) WakeUp(id string) (*WakeUpOutput, error) {
+	c.logger.Debugf("electricgopher.api.Client.WakeUp(%v): begin", id)
+	defer c.logger.Debugf("electricgopher.api.Client.WakeUp%v): end", id)
+
+	out := &WakeUpOutput{}
+	err := c.doPost(fmt.Sprintf("/api/1/vehicles/%s/wake_up", id), out, bytes.NewBufferString(""))
+	return out, err
+}
+
+type WakeUpOutput struct {
+	Response Vehicle `json:"response"`
+}
+
+func (c *Client) Unlock(id string) (*UnlockOutput, error) {
+	c.logger.Debugf("electricgopher.api.Client.Unlock(%v): begin", id)
+	defer c.logger.Debugf("electricgopher.api.Client.Unlock(%v): end", id)
+	out := &UnlockOutput{}
+	err := c.doPost(fmt.Sprintf("/api/1/vehicles/%s/command/door_unlock", id), out, bytes.NewBufferString(""))
+	return out, err
+}
+
+type UnlockOutput struct {
+	Response UnlockPayload `json:"response"`
+}
+
+type UnlockPayload struct {
+	Reason string `json:"reason"`
+	Result bool   `json:"result"`
+}

--- a/api/vehicles.go
+++ b/api/vehicles.go
@@ -12,7 +12,7 @@ type Vehicle struct {
 	Color           string   `json:"color"`
 	Tokens          []string `json:"tokens"`
 	State           string   `json:"state"`
-	InService       string   `json:"in_service"`
+	InService       bool     `json:"in_service"`
 	CalendarEnabled bool     `json:"calendar_enabled"`
 }
 


### PR DESCRIPTION
Seems that the in_service attribute has been retyped from string to bool. Looks like they changed their underlying serialization.  I'll submit a separate PR with the new fields later.  

Example response from the /api/1/vehicles client.GetVehicles call...

{"response":[{"id":xxx,"vehicle_id":xxx,"vin":"xxx","display_name":"xxx","option_codes":"AD15,MDL3,PBSB,RENA,BT37,ID3W,RF3G,S3PB,DRLH,DV2W,W39B,APF0,COUS,BC3B,CH07,PC30,FC3P,FG31,GLFR,HL31,HM31,IL31,LTPB,MR31,FM3B,RS3H,SA3P,STCP,SC04,SU3C,T3CA,TW00,TM00,UT3P,WR00,AU3P,APH3,AF00,ZCST,MI00,CDM0","color":null,"tokens":["xxx","xxx"],"state":"asleep","in_service":false,"id_s":"xxx","calendar_enabled":true,"api_version":4,"backseat_token":null,"backseat_token_updated_at":null}],"count":1}